### PR TITLE
Updated README. EasyPeasy is already Carthage compatible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI Status](http://img.shields.io/travis/nakiostudio/EasyPeasy.svg?style=flat)](https://travis-ci.org/nakiostudio/EasyPeasy)
 [![Version](https://img.shields.io/cocoapods/v/EasyPeasy.svg?style=flat)](http://cocoapods.org/pods/EasyPeasy)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen.svg)](http://cocoapods.org/pods/EasyPeasy)
 [![Docs](https://img.shields.io/cocoapods/metrics/doc-percent/EasyPeasy.svg)](http://cocoadocs.org/docsets/EasyPeasy)
 
@@ -50,6 +51,16 @@ it, simply add the following line to your Podfile:
 ```ruby
 pod "EasyPeasy"
 ```
+
+### Carthage
+EasyPeasy is [Carthage](https://github.com/Carthage/Carthage) compatible. 
+To add **EasyPeasy** as a dependency to your project, just add the following line 
+to your Cartfile:
+
+```ruby
+github "nakiostudio/EasyPeasy"
+```
+And run ` carthage update ` as usual.
 
 ### Compatibility
 For now **EasyPeasy** is only compatible with iOS 8 and above, although we aim


### PR DESCRIPTION
As requested in #9, I've tested the library as it is right now. 

The scheme is already 'shared' and Carthage builds the framework properly. I've just tested it in an empty project, pointing to the main repo and it just works, out of the box. The only concern was the symlink to the project, but it worked ok.

So I've just updated the README to state that. 

Let me know if you wish to test other scenarios.

Thanks!!
