### PR TITLE
Adopt required priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v.1.4.2
+
+* In previous versions `Priority.highPriority` matched with `UILayoutPriority.required`. This
+version introduces a new `Priority.required` case without breaking backwards compatibility as
+old priorities have been marked as deprecated in favour of `.low`, `.medium`, `.high` and
+`.custom`.
+
 ## v.1.4.1
 
 * Fixed compilation error when `EASY_RELOAD` compiler flag is set.
@@ -23,7 +30,7 @@ to views not in the view hierarchy, i.e. when `superview == nil`.
 
 ## v.1.2
 
-* Implemented `ContextualConditions`, a variant of the `Condition` closures 
+* Implemented `ContextualConditions`, a variant of the `Condition` closures
 where a `Context` struct is passed as parameter to the closure providing some
 extra information (size class and device) based on the `UITraitCollection`
 of the `UIView` the `Attributes` are going to be applied to. Examples:
@@ -33,7 +40,7 @@ view <- [
 	Size(250),
 	Center(0)
 ].when { $0.isHorizontalRegular }
-``` 
+```
 
 ```swift
 view <- [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * In previous versions `Priority.highPriority` matched with `UILayoutPriority.required`. This
 version introduces a new `Priority.required` case without breaking backwards compatibility as
 old priorities have been marked as deprecated in favour of `.low`, `.medium`, `.high` and
-`.custom`.
+`.custom`. Also `.low` now has a `Float` value of `250.0` instead of `1.0`.
 
 ## v.1.4.1
 

--- a/EasyPeasy.podspec
+++ b/EasyPeasy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "EasyPeasy"
-  s.version          = "1.4.1"
+  s.version          = "1.4.2"
   s.summary          = "EasyPeasy is a Swift framework that eases the creation of
                         Autolayout constraints programmatically"
   s.description      = <<-DESC

--- a/EasyPeasy/Attribute.swift
+++ b/EasyPeasy/Attribute.swift
@@ -112,7 +112,7 @@ open class Attribute {
      */
     public init() {
         self.constant = Constant(value: 0.0, relation: .equal, multiplier: 1.0)
-        self.priority = .highPriority
+        self.priority = .required
     }
     
     /**
@@ -124,7 +124,7 @@ open class Attribute {
      */
     public init(_ value: CGFloat) {
         self.constant = Constant(value: value, relation: .equal, multiplier: 1.0)
-        self.priority = .highPriority
+        self.priority = .required
     }
     
     /**
@@ -137,7 +137,7 @@ open class Attribute {
      */
     public init(_ constant: Constant) {
         self.constant = constant
-        self.priority = .highPriority
+        self.priority = .required
     }
     
     // MARK: Public methods

--- a/EasyPeasy/Priority.swift
+++ b/EasyPeasy/Priority.swift
@@ -39,11 +39,14 @@ public enum Priority {
     func layoutPriority() -> Float {
         switch self {
         case .customPriority(let value): return value
+        case .highPriority: return 1000.0
+        case .mediumPriority: return 500.0
+        case .lowPriority: return 1.0
         case .custom(let value): return value
-        case .highPriority, .required: return 1000.0
+        case .required: return 1000.0
         case .high: return 750.0
-        case .mediumPriority, .medium: return 500.0
-        case .lowPriority, .low: return 1.0
+        case .medium: return 500.0
+        case .low: return 250.0
         }
     }
     

--- a/EasyPeasy/Priority.swift
+++ b/EasyPeasy/Priority.swift
@@ -17,9 +17,19 @@ import Foundation
  */
 public enum Priority {
     
+    case custom(Float)
+    case required
+    case high
+    case medium
+    case low
+    
+    @available(*, deprecated, message: "Use custom case instead")
     case customPriority(Float)
+    @available(*, deprecated, message: "Use required case instead")
     case highPriority
+    @available(*, deprecated, message: "Use medium case instead")
     case mediumPriority
+    @available(*, deprecated, message: "Use low case instead")
     case lowPriority
     
     /**
@@ -29,9 +39,11 @@ public enum Priority {
     func layoutPriority() -> Float {
         switch self {
         case .customPriority(let value): return value
-        case .highPriority: return 1000.0
-        case .mediumPriority: return 500.0
-        case .lowPriority: return 1.0
+        case .custom(let value): return value
+        case .highPriority, .required: return 1000.0
+        case .high: return 750.0
+        case .mediumPriority, .medium: return 500.0
+        case .lowPriority, .low: return 1.0
         }
     }
     

--- a/Example/EasyPeasy/FeedController.swift
+++ b/Example/EasyPeasy/FeedController.swift
@@ -84,8 +84,8 @@ class FeedController: UIViewController {
                 Width(<=420),
                 Height(>=78),
                 CenterX(),
-                Left().with(.mediumPriority),
-                Right().with(.mediumPriority),
+                Left().with(.medium),
+                Right().with(.medium),
                 // Pins to top only when we place the first row
                 Top().when { index == 0 },
                 // Pins to bottom of the preivous item for the other cases

--- a/Example/Tests/AttributeTests.swift
+++ b/Example/Tests/AttributeTests.swift
@@ -360,7 +360,7 @@ class Attribute_InstallTests: XCTestCase {
         // then
         XCTAssertTrue(a.signature == "h_gt_300.0")
         XCTAssertTrue(b.signature == "v_eq_1000.0")
-        XCTAssertTrue(c.signature == "h_lt_1.0")
+        XCTAssertTrue(c.signature == "h_lt_250.0")
         XCTAssertTrue(d.signature == "h_eq_500.0")
         XCTAssertTrue(e.signature == "v_gt_1000.0")
         XCTAssertTrue(f.signature == "v_eq_1000.0")

--- a/Example/Tests/AttributeTests.swift
+++ b/Example/Tests/AttributeTests.swift
@@ -217,7 +217,7 @@ class Attribute_InstallTests: XCTestCase {
         let attributes = [Width(200), Height(500), Center(0)]
         
         // when
-        attributes.with(.customPriority(233.0))
+        attributes.with(.custom(233.0))
         
         // then
         for attribute in attributes {
@@ -347,14 +347,14 @@ class Attribute_InstallTests: XCTestCase {
     
     func testThatAGoodBunchOfAttributesHaveTheExpectedSignature() {
         // given
-        let a: Attribute = Width(>=10).with(.customPriority(300))
+        let a: Attribute = Width(>=10).with(.custom(300))
         let b: Attribute = Height(100)
-        let c: Attribute = Left(<=40).with(.lowPriority)
-        let d: Attribute = CenterXWithinMargins().with(.mediumPriority)
+        let c: Attribute = Left(<=40).with(.low)
+        let d: Attribute = CenterXWithinMargins().with(.medium)
         let e: Attribute = LastBaseline(>=30)
         let f: Attribute = BottomMargin()
         let g: Attribute = CenterYWithinMargins(<=40)
-        let h: Attribute = CenterX(>=0).with(.customPriority(244))
+        let h: Attribute = CenterX(>=0).with(.custom(244))
         
         // when
         // then

--- a/Example/Tests/CompoundAttributeTests.swift
+++ b/Example/Tests/CompoundAttributeTests.swift
@@ -24,11 +24,11 @@ class CompoundAttributeTests: XCTestCase {
     func testThatPriorityAffectsEverySubAttributeOfCompoundAttribute() {
         // given
         // when
-        let sizeAttribute = Size(CGSize(width: 100, height: 100)).with(.lowPriority)
+        let sizeAttribute = Size(CGSize(width: 100, height: 100)).with(.low)
         
         // then
         for subAttribute in sizeAttribute.attributes {
-            XCTAssertTrue(subAttribute.priority.layoutPriority() == Priority.lowPriority.layoutPriority())
+            XCTAssertTrue(subAttribute.priority.layoutPriority() == Priority.low.layoutPriority())
         }
     }
     

--- a/Example/Tests/PriorityTests.swift
+++ b/Example/Tests/PriorityTests.swift
@@ -23,6 +23,31 @@ class PriorityTests: XCTestCase {
     
     func testThatThatOrderIsCorrect() {
         // given
+        let required = Priority.required
+        let high = Priority.high
+        let medium = Priority.medium
+        let low = Priority.low
+        
+        // when
+        // then
+        XCTAssertTrue(required.layoutPriority() > high.layoutPriority())
+        XCTAssertTrue(high.layoutPriority() > medium.layoutPriority())
+        XCTAssertTrue(medium.layoutPriority() > low.layoutPriority())
+    }
+    
+    func testThatCustomPriorityRetursTheValueGiven() {
+        // given
+        let myCustomValue: Float = 234.0
+        
+        // when
+        let priority = Priority.custom(myCustomValue)
+        
+        // then
+        XCTAssertTrue(priority.layoutPriority() == myCustomValue)
+    }
+    
+    func testThatThatOrderIsCorrect_deprecatedCases() {
+        // given
         let high = Priority.highPriority
         let medium = Priority.mediumPriority
         let low = Priority.lowPriority
@@ -33,7 +58,7 @@ class PriorityTests: XCTestCase {
         XCTAssertTrue(medium.layoutPriority() > low.layoutPriority())
     }
 
-    func testThatCustomPriorityRetursTheValueGiven() {
+    func testThatCustomPriorityRetursTheValueGiven_deprecatedCases() {
         // given
         let myCustomValue: Float = 234.0
         

--- a/Example/Tests/UILayoutGuide+EasyTests.swift
+++ b/Example/Tests/UILayoutGuide+EasyTests.swift
@@ -144,8 +144,8 @@ class UILayoutGuide_EasyTests: XCTestCase {
             Top(20),
             Width(<=200),
             Bottom(20),
-            Left(10).with(.lowPriority),
-            Right(10).with(.lowPriority)
+            Left(10).with(.low),
+            Right(10).with(.low)
         ]
         XCTAssertTrue(superview.constraints.count == 5)
         XCTAssertTrue(layoutGuide.test_attributes.count == 5)
@@ -166,8 +166,8 @@ class UILayoutGuide_EasyTests: XCTestCase {
         let layoutGuide = UILayoutGuide()
         superview.addLayoutGuide(layoutGuide)
         layoutGuide <- [
-            Left(10).with(.lowPriority).when { [weak self] in return (self!.aFlag) },
-            Left(100).with(.lowPriority).when { [weak self] in return !(self!.aFlag) }
+            Left(10).with(.low).when { [weak self] in return (self!.aFlag) },
+            Left(100).with(.low).when { [weak self] in return !(self!.aFlag) }
         ]
         XCTAssertTrue(superview.constraints.count == 1)
         XCTAssertTrue(layoutGuide.test_attributes.count == 2)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Carthage compatible](https://img.shields.io/badge/carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen.svg)](https://travis-ci.org/nakiostudio/EasyPeasy)
 [![Docs](https://img.shields.io/cocoapods/metrics/doc-percent/EasyPeasy.svg)](http://cocoadocs.org/docsets/EasyPeasy)
-[![CocoaPods](https://img.shields.io/cocoapods/dt/EasyPeasy.svg)](http://cocoapods.org/pods/EasyPeasy)
 
 **EasyPeasy** is a Swift framework that lets you create *Auto Layout* constraints
 programmatically without headaches and never ending boilerplate code. Besides the
@@ -271,22 +270,24 @@ view <- CenterWithinMargins(CGPoint(x: 0, y: 50))
 ### Priorities
 
 The `Priority` enum does the same function as `UILayoutPriority` and it's shaped
-by four cases:
-* `LowPriority`: it creates an *Auto Layout* priority with `Float` value `1`.
+by five cases:
+* `low`: it creates an *Auto Layout* priority with `Float` value `1`.
 
-* `MediumPriority`: it creates an *Auto Layout* priority with `Float` value `500`.
+* `medium`: it creates an *Auto Layout* priority with `Float` value `500`.
 
-* `HighPriority`: it creates an *Auto Layout* priority with `Float` value `1000`.
+* `high`: it creates an *Auto Layout* priority with `Float` value `750`.
 
-* `CustomPriority`: it specifies the *Auto Layout* priority defined by the
-developer in the case associated value `value`. Example: `.CustomPriority(value: 750.0)`
+* `required`: it creates an *Auto Layout* priority with `Float` value `1000`.
+
+* `custom`: it specifies the *Auto Layout* priority defined by the
+developer in the case associated value `value`. Example: `.custom(value: 650.0)`.
 
 In order to apply any of these priorities to an `Attribute`, the method
 `.with(priority: Priority)` must be used. The following example gives an
 `UILayoutPriority` of `500` to the `Top` `Attribute` applied to `view`:
 
 ```swift
-view <- Top(>=50).with(.MediumPriority)
+view <- Top(>=50).with(.medium)
 ```
 
 You can also apply a `Priority` to an array of `Attributes` (this operation will
@@ -296,7 +297,7 @@ override the priorities previously applied to an `Attribute`).
 view <- [
 	Width(200),
 	Height(200)
-].with(.MediumPriority)
+].with(.medium)
 ```
 
 ### Conditions


### PR DESCRIPTION
In previous versions `Priority.highPriority` matched with `UILayoutPriorityRequired`. This version introduces a new `Priority.required` case without breaking backwards compatibility as old priorities have been marked as deprecated in favour of `.low`, `.medium`, `.high` and `.custom`. Also `.low` now has a `Float` value of `250.0` instead of `1.0`.