### PR TITLE
Fix * operator which would set value not just for multiplier but also for constant

### DIFF
--- a/EasyPeasy/Constant.swift
+++ b/EasyPeasy/Constant.swift
@@ -112,7 +112,7 @@ public extension CGFloat {
         - returns: The resulting `Constant` struct
      */
     public static prefix func * (rhs: CGFloat) -> Constant {
-        return Constant(value: rhs, relation: .equal, multiplier: rhs)
+        return Constant(value: 0, relation: .equal, multiplier: rhs)
     }
 
     /**

--- a/Example/Tests/CompoundAttributeTests.swift
+++ b/Example/Tests/CompoundAttributeTests.swift
@@ -91,7 +91,7 @@ class CompoundAttributeTests: XCTestCase {
         
         // then
         for attribute in sizeAttribute.attributes {
-            XCTAssertTrue(attribute.constant.value == 2.0)
+            XCTAssertTrue(attribute.constant.value == 0.0)
             XCTAssertTrue(attribute.constant.relation == .equal)
             XCTAssertTrue(attribute.constant.multiplier == 2.0)
         }
@@ -173,7 +173,7 @@ class CompoundAttributeTests: XCTestCase {
         
         // then
         for attribute in edgesAttribute.attributes {
-            XCTAssertTrue(attribute.constant.value == 2.0)
+            XCTAssertTrue(attribute.constant.value == 0.0)
             XCTAssertTrue(attribute.constant.relation == .equal)
             XCTAssertTrue(attribute.constant.multiplier == 2.0)
         }
@@ -248,7 +248,7 @@ class CompoundAttributeTests: XCTestCase {
         
         // then
         for attribute in centerAttribute.attributes {
-            XCTAssertTrue(attribute.constant.value == 2.0)
+            XCTAssertTrue(attribute.constant.value == 0.0)
             XCTAssertTrue(attribute.constant.relation == .equal)
             XCTAssertTrue(attribute.constant.multiplier == 2.0)
         }
@@ -315,7 +315,7 @@ class CompoundAttributeTests: XCTestCase {
         
         // then
         for attribute in centerWithinMarginsAttribute.attributes {
-            XCTAssertTrue(attribute.constant.value == 2.0)
+            XCTAssertTrue(attribute.constant.value == 0.0)
             XCTAssertTrue(attribute.constant.relation == .equal)
             XCTAssertTrue(attribute.constant.multiplier == 2.0)
         }
@@ -382,7 +382,7 @@ class CompoundAttributeTests: XCTestCase {
         
         // then
         for attribute in marginsAttribute.attributes {
-            XCTAssertTrue(attribute.constant.value == 2.0)
+            XCTAssertTrue(attribute.constant.value == 0.0)
             XCTAssertTrue(attribute.constant.relation == .equal)
             XCTAssertTrue(attribute.constant.multiplier == 2.0)
         }

--- a/Example/Tests/ConstantTests.swift
+++ b/Example/Tests/ConstantTests.swift
@@ -57,7 +57,7 @@ class ConstantTests: XCTestCase {
         let constant = (*5)
         
         // then
-        XCTAssertTrue(constant.value == 5)
+        XCTAssertTrue(constant.value == 0)
         XCTAssertTrue(constant.relation == .equal)
         XCTAssertTrue(constant.multiplier == 5.0)
     }
@@ -137,7 +137,7 @@ class ConstantTests: XCTestCase {
         // then
         XCTAssertTrue(greaterThanValue == 200.0)
         XCTAssertTrue(lessThanValue == 200.0)
-        XCTAssertTrue(multipliedByValue == 200.0)
+        XCTAssertTrue(multipliedByValue == 0.0)
         XCTAssertTrue(equalToValue == 200.0)
         XCTAssertTrue(equalToPrefValue == 200.0)
     }


### PR DESCRIPTION
We've found an issue in one of the project that is using EasyPeasy. When you create a constraint using `*` operator (e.g. `Width(*1.5)`), it would set not just the `multiplier` to `1.5` but also the `constant`. As a workaround we're currently always explicitly providing a constant: `Width(==0 *1.5)`.
