### PR TITLE
Fix * prefix operator

### DIFF
--- a/EasyPeasy/Constant.swift
+++ b/EasyPeasy/Constant.swift
@@ -114,7 +114,7 @@ public extension CGFloat {
         - returns: The resulting `Constant` struct
      */
     static prefix func * (rhs: CGFloat) -> Constant {
-        return Constant(value: rhs, relation: .equal, multiplier: rhs)
+        return Constant(value: 0, relation: .equal, multiplier: rhs)
     }
 
     /**


### PR DESCRIPTION
`value` was set to `rhs` instead of zero