### PR TITLE
Fix reload()

### DIFF
--- a/EasyPeasy/Item.swift
+++ b/EasyPeasy/Item.swift
@@ -86,8 +86,8 @@ extension Item {
         }
         
         // Activate/deactivate the resulting `NSLayoutConstraints`
-        NSLayoutConstraint.deactivate(deactivateConstraints)
         NSLayoutConstraint.activate(activateConstraints)
+        NSLayoutConstraint.deactivate(deactivateConstraints)
     }
     
     /**


### PR DESCRIPTION
For some reason `activateConstraints` and `deactivateConstraints` might contain same constraints. That requires further investigation but deactivating after activating solves the consequences of the issue in my case.