### PR TITLE
Rename Context to EasyContext and View to EasyView for SwiftUI compatibility

### DIFF
--- a/EasyPeasy/Attribute.swift
+++ b/EasyPeasy/Attribute.swift
@@ -25,13 +25,13 @@ public typealias Condition = () -> Bool
 
 #if os(iOS)
 /**
-    Typealias of a closure with a `Context` struct as parameter and `Bool`
+    Typealias of a closure with an `EasyContext` struct as parameter and `Bool`
     as returning type.
 
     This type of closure is used to evaluate whether an `Attribute` should
     be applied or not.
  */
-public typealias ContextualCondition = (Context) -> Bool
+public typealias ContextualCondition = (EasyContext) -> Bool
 #endif
 
 /**
@@ -240,8 +240,8 @@ open class Attribute {
         // struct and call the closure
         #if os(iOS)
         let item = self.createItem?.owningView ?? self.createItem
-        if let contextualCondition = self.condition as? ContextualCondition, let view = item as? View {
-            return contextualCondition(Context(with: view.traitCollection))
+        if let contextualCondition = self.condition as? ContextualCondition, let view = item as? EasyView {
+            return contextualCondition(EasyContext(with: view.traitCollection))
         }
         #endif
         

--- a/EasyPeasy/Context.swift
+++ b/EasyPeasy/Context.swift
@@ -16,7 +16,7 @@ import UIKit
      Struct that from an `UITraitCollection` object populates some helper 
      properties easing access to device and size class information
  */
-public struct Context {
+public struct EasyContext {
     
     /// `true` if the current device is an iPad
     public let isPad: Bool

--- a/EasyPeasy/Item+AppKit.swift
+++ b/EasyPeasy/Item+AppKit.swift
@@ -13,7 +13,7 @@
 import AppKit
 
 /// Alias of NSView
-public typealias View = NSView
+public typealias EasyView = NSView
     
 /**
      Extension making `NSView` conform the `Item` protocol and
@@ -23,7 +23,7 @@ extension NSView: Item {
     
     /// Owning `NSView` for the current `Item`. The concept varies
     /// depending on the class conforming the protocol
-    public var owningView: View? {
+    public var owningView: EasyView? {
         // Owning view for `NSView` is the `superview`
         return self.superview
     }

--- a/EasyPeasy/Item+UIKit.swift
+++ b/EasyPeasy/Item+UIKit.swift
@@ -13,7 +13,7 @@
 import UIKit
     
 /// Alias of UIView
-public typealias View = UIView
+public typealias EasyView = UIView
     
 /**
      Extension making `UIView` conform the `Item` protocol and
@@ -23,7 +23,7 @@ extension UIView: Item {
 
     /// Owning `UIView` for the current `Item`. The concept varies
     /// depending on the class conforming the protocol
-    public var owningView: View? {
+    public var owningView: EasyView? {
         return self.superview
     }
     

--- a/EasyPeasy/Item.swift
+++ b/EasyPeasy/Item.swift
@@ -33,7 +33,7 @@ public protocol Item: NSObjectProtocol {
     
     /// Owning `UIView` for the current `Item`. The concept varies
     /// depending on the class conforming the protocol
-    var owningView: View? { get }
+    var owningView: EasyView? { get }
     
 }
 

--- a/Example/Tests/ContextTests.swift
+++ b/Example/Tests/ContextTests.swift
@@ -34,7 +34,7 @@ class ContextTests: XCTestCase {
         let isVerticalRegular = view.traitCollection.verticalSizeClass == .regular
         
         // when
-        let context = Context(with: view.traitCollection)
+        let context = EasyContext(with: view.traitCollection)
         
         // then
         XCTAssertTrue(context.isPad == isPad)
@@ -60,7 +60,7 @@ class ContextTests: XCTestCase {
         let isVerticalRegular = traitCollection.verticalSizeClass == .regular
         
         // when
-        let context = Context(with: traitCollection)
+        let context = EasyContext(with: traitCollection)
         
         // then
         XCTAssertTrue(context.isPad == isPad)
@@ -86,7 +86,7 @@ class ContextTests: XCTestCase {
         let isVerticalRegular = traitCollection.verticalSizeClass == .regular
         
         // when
-        let context = Context(with: traitCollection)
+        let context = EasyContext(with: traitCollection)
         
         // then
         XCTAssertTrue(context.isPad == isPad)
@@ -112,7 +112,7 @@ class ContextTests: XCTestCase {
         let isVerticalRegular = traitCollection.verticalSizeClass == .regular
         
         // when
-        let context = Context(with: traitCollection)
+        let context = EasyContext(with: traitCollection)
         
         // then
         XCTAssertTrue(context.isPad == isPad)
@@ -138,7 +138,7 @@ class ContextTests: XCTestCase {
         let isVerticalRegular = traitCollection.verticalSizeClass == .regular
         
         // when
-        let context = Context(with: traitCollection)
+        let context = EasyContext(with: traitCollection)
         
         // then
         XCTAssertTrue(context.isPad == isPad)

--- a/Example/Tests/ItemTests.swift
+++ b/Example/Tests/ItemTests.swift
@@ -103,7 +103,7 @@ class ItemTests: XCTestCase {
                 }
             }
             
-            fileprivate var owningView: View?
+            fileprivate var owningView: EasyView?
             
         }
         let testClassInstance = TestClass()

--- a/README.md
+++ b/README.md
@@ -361,11 +361,11 @@ view.easy.layout([
 
 #### ContextualConditions
 This iOS only feature is a variant of the `Condition` closures that receive no
-parameters and return a boolean value. Instead, a `Context` struct is passed
+parameters and return a boolean value. Instead, an `EasyContext` struct is passed
 as parameter providing some extra information based on the `UITraitCollection`
 of the `UIView` the `Attributes` are going to be applied to.
 
-The properties available on this `Context` struct are:
+The properties available on this `EasyContext` struct are:
 
 * `isPad`: true if the current device is iPad.
 * `isPhone`: true if the current device is iPhone.


### PR DESCRIPTION
SwiftUI introduces the structs `View` and `Context`. EasyPeasy's own structs of the same name conflict with this, which leads to errors in files where you include both SwiftUI and EasyPeasy.

This PR renames EasyPeasy's `View` and `Context` to `EasyView` and `EasyContext`. This fixes the incompatibility. I've decided not to rename file names, so `Context.swift` remains `Context.swift`, as that felt more in line with the other filenames.