### PR TITLE
Add Edges().to(_:) - Enables to attach the edge of the view to another view or LayoutGuide.

### DIFF
--- a/EasyPeasy/PositionAttribute+UIKit.swift
+++ b/EasyPeasy/PositionAttribute+UIKit.swift
@@ -324,5 +324,29 @@ public class CenterWithinMargins: CompoundAttribute {
     }
     
 }
+
+extension Edges {
+  
+  @available(iOS 9.0, *)
+  public func to(_ layoutGuide: UILayoutGuide) -> Edges {
+    self.attributes = [
+      Top().to(layoutGuide, .top),
+      Left().to(layoutGuide, .left),
+      Right().to(layoutGuide, .right),
+      Bottom().to(layoutGuide, .bottom),
+    ]
+    return self
+  }
+  
+  public func to(_ view: UIView) -> Edges {
+    self.attributes = [
+      Top().to(view, .top),
+      Left().to(view, .left),
+      Right().to(view, .right),
+      Bottom().to(view, .bottom),
+    ]
+    return self
+  }
+}
     
 #endif


### PR DESCRIPTION
PR adds methods to enable to attach edges of view to other layout-guide or view.

## Motivation

I often write the following code in order to attach the edges of the view to UILayoutGuide.
This code is a bit verbosity, and we could have a shorthand if we could add a method to `Edges`.

Before:
```swift
 myOverlayView.easy.layout([
    Top().to(overlayViewLayoutGuide, .top),
    Left().to(overlayViewLayoutGuide, .left),
    Right().to(overlayViewLayoutGuide, .right),
    Bottom().to(overlayViewLayoutGuide, .bottom),
  ])
```

After:

```swift
 myOverlayView.easy.layout(
   Edges().to(overlayViewLayoutGuide)
 )
```
