### PR TITLE
Add workflows that enable to create release automatically in CocoaPods

### DIFF
--- a/.github/workflows/Checks.yml
+++ b/.github/workflows/Checks.yml
@@ -1,0 +1,15 @@
+name: Checks
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: macos-latest
+
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1.1
+        with:
+          xcode-version: "12.3"
+      - uses: actions/checkout@v2
+      - name: Lint Cocoapods
+        run: pod lib lint --allow-warnings

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  pod-trunk-push:
+    runs-on: macOS-latest
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1.1
+        with:
+          xcode-version: "12.3"
+      - uses: actions/checkout@v2
+      - name: Deploy
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: pod trunk push EasyPeasy.podspec --allow-warnings


### PR DESCRIPTION
- Add workflows that run on GitHub Actions.
- These are:
  - Check podspec is valid (linting)
  - Push to cocoapods repo automatically when we create a tag.


## TODO

- [x] Set a secure variable `COCOAPODS_TRUNK_TOKEN` to create cocoapods release from GitHub Actions.