### PR TITLE
Say no to commas: add array builder to layout

### DIFF
--- a/ArrayBuilder.swift
+++ b/ArrayBuilder.swift
@@ -1,0 +1,50 @@
+// The MIT License (MIT) - Copyright (c) 2016 Carlos Vidal
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if swift(>=5.4)
+import Foundation
+
+@resultBuilder
+public enum EasyPeasyArrayBuilder<T> {
+    public typealias Component = [T]
+
+    public static func buildExpression(_ expression: T) -> Component {
+        [expression]
+    }
+
+    public static func buildExpression(_ expression: Component) -> Component {
+        expression
+    }
+
+    public static func buildExpression(_ expression: Void) -> Component {
+        []
+    }
+
+    public static func buildBlock(_ components: Component...) -> Component {
+        buildArray(components)
+    }
+
+    public static func buildEither(first component: Component) -> Component {
+        component
+    }
+
+    public static func buildEither(second component: Component) -> Component {
+        component
+    }
+
+    public static func buildOptional(_ component: Component?) -> Component {
+        component ?? []
+    }
+
+    public static func buildArray(_ components: [Self.Component]) -> Self.Component {
+        components.flatMap{ $0 }
+    }
+}
+#endif

--- a/EasyPeasy/EasyPeasy.swift
+++ b/EasyPeasy/EasyPeasy.swift
@@ -62,3 +62,15 @@ public struct EasyPeasy {
     
 }
 
+#if swift(>=5.4)
+extension EasyPeasy {
+    /**
+         Applies the attributes given to the current item
+         - parameter attributes: `Attributes` applied to the `Item`
+         - returns: The array of `NSLayoutConstraints` created and applied
+     */
+    @discardableResult public func layout(@EasyPeasyArrayBuilder<Attribute> _ builder: () -> [Attribute]) -> [NSLayoutConstraint] {
+        return self.item?.apply(attributes: builder()) ?? []
+    }
+}
+#endif


### PR DESCRIPTION
Result builder hit the [swift 5.4](https://github.com/apple/swift-evolution/blob/main/proposals/0289-result-builders.md). Array result builder allows to refuse from commas when you create an array. The example of usage: 
```
self.thumbnailImageView.easy.layout {
    Size(52)
    Top(12)
    Left(12)
}
```